### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ launch the demo from the index table.
 	module.exports = demoInfo; //make it public
 
 
-Appart of the demo folder, you may want to add some new components to the app. Add your custom components inside components folder.
+Apart of the demo folder, you may want to add some new components to the app. Add your custom components inside components folder.
 	
 Code strong!
 


### PR DESCRIPTION
@jaraen, I've corrected a typographical error in the documentation of the [TitanTricks](https://github.com/jaraen/TitanTricks) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
